### PR TITLE
Rewritten install manual

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -6,49 +6,49 @@ Installation
 
 To start with `GraphQL <https://www.graphql.org>`_ you need `OXID eShop <https://www.oxid-esales.com/>`_ up and running (at least ``OXID-eSales/oxideshop_ce: v6.5.0`` component, which is part of the ``6.2.0`` compilation).
 
-To install the available GraphQL modules, first you have to go to the shop's directory
+First navigate to your shop's root directory where the project ``composer.json`` file is located:
 
 .. code-block:: bash
 
     cd <shop_directory>
 
-and to require the modules via ``composer``:
+Then you can simply install the module(s) by using ``composer require`` command. In most cases you want the full GraphQL integration by OXID including the schema for the OXID eShop storefront. To achieve this you need to install the **OXID GraphQL Storefront** module:
+
+.. code-block:: bash
+
+    composer require oxid-esales/graphql-storefront
+
+This will automatically install the **OXID GraphQL Base** module, which is needed for general GraphQL integration into the OXID eShop. In case you only need the basic GraphQL integration and want to implement your own queries and mutations, you can also install the **GraphQL Base** module exclusively:
 
 .. code-block:: bash
 
     composer require oxid-esales/graphql-base
-    composer require oxid-esales/graphql-storefront
 
-After installing the modules you need to add their configurations into the project's
-configuration file and run migrations. You can do it by running:
+If you decided to go with the **GraphQL Storefront** module, you need to run migrations after the installation was successfully executed:
 
 .. code-block:: bash
 
-    ./vendor/bin/oe-console oe:module:install-configuration source/modules/oe/graphql-base/
-    ./vendor/bin/oe-console oe:module:install-configuration source/modules/oe/graphql-storefront/
-
-    ./vendor/bin/oe-eshop-doctrine_migration migration:migrate oe_graphql_storefront
-
-This will overwrite the configuration of the modules if it was already present in the project's configuration file.
-
-.. important::
-    Please ensure you have proper ``/graphql/`` entry point configuration in
-    your ``.htaccess`` file:
-
-    .. code-block:: bash
-
-        RewriteRule ^graphql/?$    widget.php?cl=graphql&skipSession=1   [QSA,NC,L]
+    vendor/bin/oe-eshop-doctrine_migration migration:migrate oe_graphql_storefront
 
 Activation
 ----------
 
-Now you need to activate the modules, either via OXID eShop admin or CLI.
+Now you need to activate the modules. You can do this in the OXID eShop administration area or by using the CLI.
 
 .. code-block:: bash
 
-    ./vendor/bin/oe-console oe:module:activate oe_graphql_base
-    ./vendor/bin/oe-console oe:module:activate oe_graphql_storefront
-
+    vendor/bin/oe-console oe:module:activate oe_graphql_base
+    vendor/bin/oe-console oe:module:activate oe_graphql_storefront
 
 .. important::
+
     Keep in mind that you have to activate the **GraphQL Base** module first.
+
+Entry Point Configuration
+-------------------------
+
+The GraphQL API uses the single entry point ``/graphql/``. Usually this entry point is configured in the ``.htaccess`` file that is coming with the OXID eShop. However, if you encounter trouble with that, ensure you have the proper ``/graphql/`` entry point configuration in your ``.htaccess`` file or add it, if not present:
+
+.. code-block:: bash
+
+    RewriteRule ^graphql/?$    widget.php?cl=graphql&skipSession=1   [QSA,NC,L]


### PR DESCRIPTION
Rewritten the install manual due to several commands that are actually not needed and may be misleading instead.
- Splitted installation of Base from Storefront, since it is installed automatically.
- Described installation of Base alone, if needed/wanted.
- Removed install-configuration commands, since they are run automatically by our composer plugin.
- Moved entry point configuration to a separate section at the end.
- Enriched all descriptions with some more information so the user knows better what he does.