### PR TITLE
Updated description, added specific version and migration for base.

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,14 +1,14 @@
 Install and Setup
 =================
 
-Installation
-------------
-
 To start with `GraphQL <https://www.graphql.org>`_ you need `OXID eShop <https://www.oxid-esales.com/>`_ up and running (at least ``OXID-eSales/oxideshop_ce: v6.5.0`` component, which is part of the ``6.2.0`` compilation).
 
 .. attention::
 
     Depending on your current shop version, you need to install a suitable version of the **OXID GraphQL API**. This installation manual is compatible with OXID eShop 6.5. For newer or older versions, please see the corresponding documentations.
+
+Installation
+------------
 
 First navigate to your shop's root directory where the project ``composer.json`` file is located:
 
@@ -28,7 +28,16 @@ This will automatically install the **OXID GraphQL Base** module, which is neede
 
     composer require oxid-esales/graphql-base:^7.0
 
-If you decided to go with the **GraphQL Storefront** module, you need to run migrations after the installation was successfully executed:
+Migration
+---------
+
+After the installation you need to run the migrations for the **GraphQL Base** module:
+
+.. code-block:: bash
+
+    ./vendor/bin/oe-eshop-doctrine_migration migration:migrate oe_graphql_base
+
+And if you decided to go with the **GraphQL Storefront** module, you must execute migrations for this one as well:
 
 .. code-block:: bash
 
@@ -37,7 +46,7 @@ If you decided to go with the **GraphQL Storefront** module, you need to run mig
 Activation
 ----------
 
-Now you need to activate the modules, either via OXID eShop admin or CLI.
+Now you need to activate the modules, either via OXID eShop administration area or the CLI:
 
 .. code-block:: bash
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -6,38 +6,33 @@ Installation
 
 To start with `GraphQL <https://www.graphql.org>`_ you need `OXID eShop <https://www.oxid-esales.com/>`_ up and running (at least ``OXID-eSales/oxideshop_ce: v6.5.0`` component, which is part of the ``6.2.0`` compilation).
 
-To install the available GraphQL modules, first you have to go to the shop's directory
+.. attention::
+
+    Depending on your current shop version, you need to install a suitable version of the **OXID GraphQL API**. This installation manual is compatible with OXID eShop 6.5. For newer or older versions, please see the corresponding documentations.
+
+First navigate to your shop's root directory where the project ``composer.json`` file is located:
 
 .. code-block:: bash
 
     cd <shop_directory>
 
-and to require the modules via ``composer``:
+Then you can simply install the module(s) by using ``composer require`` command. In most cases you want the full GraphQL integration by OXID including the schema for the shop's storefront. To achieve this you need to install the **OXID GraphQL Storefront** module:
 
 .. code-block:: bash
 
-    composer require oxid-esales/graphql-base
-    composer require oxid-esales/graphql-storefront
+    composer require oxid-esales/graphql-storefront:~2.1.0
 
-After installing the modules you need to add their configurations into the project's
-configuration file and run migrations. You can do it by running:
+This will automatically install the **OXID GraphQL Base** module, which is needed for general GraphQL integration. In case you only need the basic GraphQL integration and want to implement your own queries and mutations, you can also install the **GraphQL Base** module exclusively:
 
 .. code-block:: bash
 
-    ./vendor/bin/oe-console oe:module:install-configuration source/modules/oe/graphql-base/
-    ./vendor/bin/oe-console oe:module:install-configuration source/modules/oe/graphql-storefront/
+    composer require oxid-esales/graphql-base:^7.0
+
+If you decided to go with the **GraphQL Storefront** module, you need to run migrations after the installation was successfully executed:
+
+.. code-block:: bash
 
     ./vendor/bin/oe-eshop-doctrine_migration migration:migrate oe_graphql_storefront
-
-This will overwrite the configuration of the modules if it was already present in the project's configuration file.
-
-.. important::
-    Please ensure you have proper ``/graphql/`` entry point configuration in
-    your ``.htaccess`` file:
-
-    .. code-block:: bash
-
-        RewriteRule ^graphql/?$    widget.php?cl=graphql&skipSession=1   [QSA,NC,L]
 
 Activation
 ----------


### PR DESCRIPTION
This PR corresponds to PR https://github.com/OXID-eSales/graphql-base-module/pull/26. It adds the specific versions to be safe on installation even though we release new GraphQL or shop version. It als uniforms the installation manual from OXID GraphQL API 6 and 7.