### PR TITLE
Updated dependencies of lcobucci/jwt

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": "^7.4|^8.0",
         "ext-json": "*",
         "thecodingmachine/graphqlite": "^5.0.2",
-        "lcobucci/jwt": "^4.0",
+        "lcobucci/jwt": "^4.1",
         "symfony/cache": "*",
         "ecodev/graphql-upload": "^6.1",
         "laminas/laminas-diactoros": "^2.5",


### PR DESCRIPTION
We are using `Lcobucci\JWT\Validation\Constraint\StrictValidAt` class in GraphQL Base Module:
https://github.com/OXID-eSales/graphql-base-module/blob/152f5ed161a3520c04dcb940b57962271c21a174/src/Service/JwtConfigurationBuilder.php#L19

This class was introduced in Minor Release 4.1 of lcobucci/jwt. The GraphQL Base Module requires `"lcobucci/jwt": "^4.0"`:
https://github.com/OXID-eSales/graphql-base-module/blob/152f5ed161a3520c04dcb940b57962271c21a174/composer.json#L20

This may work, but also might not. In my test system it worked since it installed 4.1, but another user experienced issues due to installation of 4.0, which is accepted by the requirement `"lcobucci/jwt": "^4.0"` and probably forced by another package requiring lcobucci/jwt especially in version 4.0. This leads to errors obviously.

To grant a working GraphQL Base Module, we must update the requirements accordingly.